### PR TITLE
Wait for Google Home announcement to complete

### DIFF
--- a/lib/speech2device.js
+++ b/lib/speech2device.js
@@ -189,8 +189,20 @@ function Speech2Device(adapter, libs, options) {
         var announcementJSON = JSON.stringify(announcement);
 
         if (adapter.config.cDevice && options.webLink) {
-            adapter.log.info('Set "' + adapter.config.cDevice + '.player.announcement: ' + announcementJSON);
-            adapter.setForeignState(adapter.config.cDevice + '.player.announcement', announcementJSON);
+            var chromecast_anouncement_dev = adapter.config.cDevice + '.player.announcement';
+            adapter.log.info('Set "' + chromecast_anouncement_dev + ' to ' + announcementJSON);
+            adapter.setForeignState(chromecast_anouncement_dev, announcementJSON, function () {
+              //Check every 500 ms if the announcement has finished playing
+              var intervalHandler = setInterval(function(){
+                adapter.getForeignState(chromecast_anouncement_dev, function(err, state) {
+                  if(!err && state.ack) {
+                    adapter.log.debug(chromecast_anouncement_dev + ' finished playing announcement: '+announcementJSON);
+                    clearInterval(intervalHandler);
+                    callback();
+                  }
+                });
+              }, 500);
+            });
         } else {
             adapter.log.warn('Web server is unavailable!');
         }


### PR DESCRIPTION
Without this fix there is a race condition when playing an announcement: the text get played twice instead.

This fix only works if the Google Home adapter (chromecast) is at least 1.3.5. Without the same race condition still happens since the Google Home adapter acknowledged the announcement before finishing playing it.