### PR TITLE
Use mpg321 volume option instead of amixer

### DIFF
--- a/lib/speech2device.js
+++ b/lib/speech2device.js
@@ -13,7 +13,6 @@ function Speech2Device(adapter, libs, options) {
     };
     var MP3FILE    = __dirname + '/../say.mp3';
     var that       = this;
-    var stateVolume;
 
     // Google home
     var Client;
@@ -429,7 +428,7 @@ function Speech2Device(adapter, libs, options) {
                 if (adapter.config.player === 'omxplayer') {
                     cmd = 'omxplayer -o local ' + file;
                 } else {
-                    cmd = 'mpg321 -g ' + stateVolume + ' ' + file;
+                    cmd = 'mpg321 -g ' + options.sayLastVolume + ' ' + file;
                 }
                 ls = libs.child_process.exec(cmd, function (error /* , stdout, stderr */) {
                     if (error) adapter.log.error('Cannot play:' + error);
@@ -513,7 +512,6 @@ function Speech2Device(adapter, libs, options) {
 
         if (level === options.sayLastVolume) return;
         if (!libs.os) libs.os = require('os');
-        stateVolume = level;
 
         adapter.setState('tts.volume', level, true);
 

--- a/lib/speech2device.js
+++ b/lib/speech2device.js
@@ -13,6 +13,7 @@ function Speech2Device(adapter, libs, options) {
     };
     var MP3FILE    = __dirname + '/../say.mp3';
     var that       = this;
+    var stateVolume;
 
     // Google home
     var Client;
@@ -428,7 +429,7 @@ function Speech2Device(adapter, libs, options) {
                 if (adapter.config.player === 'omxplayer') {
                     cmd = 'omxplayer -o local ' + file;
                 } else {
-                    cmd = 'mpg321 ' + file;
+                    cmd = 'mpg321 -g ' + stateVolume + ' ' + file;
                 }
                 ls = libs.child_process.exec(cmd, function (error /* , stdout, stderr */) {
                     if (error) adapter.log.error('Cannot play:' + error);
@@ -512,6 +513,7 @@ function Speech2Device(adapter, libs, options) {
 
         if (level === options.sayLastVolume) return;
         if (!libs.os) libs.os = require('os');
+        stateVolume = level;
 
         adapter.setState('tts.volume', level, true);
 
@@ -520,7 +522,7 @@ function Speech2Device(adapter, libs, options) {
         var p  = libs.os.platform();
         var ls = null;
 
-        if (p === 'linux') {
+        if (p === 'linux' && adapter.config.player !== 'mpg321') {
             //linux
             try {
                 ls = libs.child_process.spawn('amixer', ['cset', 'name="Master Playback Volume"', '--', level + '%']);


### PR DESCRIPTION
Changed the way the adapter sets the volume on linux systems when its using mpg321 for playback.

The adapter is setting the volume with
`libs.child_process.spawn('amixer', ['cset', 'name="Master Playback Volume"', '--', level + '%']);`
But on some linux systems the "Master Playback Volume" is not available at all..
So in my opinion its not "safe" to set the volume that way..

I decided to just do it the simple way:
If we are running on linux and using mpg321 as player - then pass the volume directly to mpg321 with this command:
`mpg321 -g VOLUME file.mp3`
and dont try to set the volume with amixer.

Already testet on my Raspberry.. 
Changing the tts.volume State did not work in the past. 
Now with that change - it works flawlessly! :+1: 