### PR TITLE
ip range check with sonos fixed

### DIFF
--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -214,9 +214,9 @@
                             var server;
                             var type = $('#type').val();
                             if (type === 'googleHome') {
-                                 server = $('#server').val();
+                                server = $('#server').val();
                             } else if (type === 'sonos') {
-                                server = $('#device').val();
+                                server = $('#device').val().split('.')[3].replace('_', '.').replace('_', '.').replace('_', '.');
                             } else if (type === 'chromecast') {
                                 server = $('#cDevice').val();
                             } else if (type === 'mpd') {


### PR DESCRIPTION
When selecting sonos, the ip address range check (ip2hex etc.) fails because the value of $('#device').val() is "sonos.<instance>.<ip>". This should fix this problem.