### PR TITLE
Support for Yandex.Cloud SpeechKIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ The file must be first loaded.
 online:  
 - Google: English, German, Russian, Italian, Spanish, French
 - Yandex: Russian  
-  To use Yandex voices you must request the API key here: [https://tech.yandex.ru/speechkit/cloud/doc/dg/concepts/About-docpage/](https://tech.yandex.ru/speechkit/cloud/doc/dg/concepts/About-docpage/).  
+  To use Yandex voices you must request the API key here: [https://tech.yandex.ru/speechkit/cloud/doc/dg/concepts/About-docpage/](https://tech.yandex.ru/speechkit/cloud/doc/dg/concepts/About-docpage/).  [This service will be disabled 1st of Jan 2019 and replaced by Yandex.cloud]
+  To use Yandex.cloud you should register here: [https://cloud.yandex.ru/], install SpeechKIT API in the Cloud and get Auth Token and Folder ID as described in API instructions.
 - Ivona: English, German, Russian, Italian, Spanish, French, Dansk, Welsh, Icelandic, Dutch, Polish, Portuguese, Romanian, Swedish, Turkish  
         To use Amazon(Ivona) voices you need to get access key and secret key [here](http://www.ivona.com/us/for-business/speech-cloud/).
 - Cloud:
@@ -123,6 +124,7 @@ Following values for engines are possible:
 
 #### Yandex
 - **ru_YA:Yandex** - Русский
+- **ru_YA_CLOUD:Yandex Cloud** - Русский
 
 #### Amazon polly via cloud
 - **ru-RU_CLOUD_Female** -         Русский - Татьяна

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Following values for engines are possible:
 
 #### Yandex
 - **ru_YA:Yandex** - Русский
-- **ru_YA_CLOUD:Yandex Cloud** - Русский
+- **ru_YA_CLOUD:Yandex Cloud** - Русский [Yandex.Cloud API generates files in OGG format. To play ogg files on linux mplayer should be installed and selected as system player]
 
 #### Amazon polly via cloud
 - **ru-RU_CLOUD_Female** -         Русский - Татьяна

--- a/admin/blockly.js
+++ b/admin/blockly.js
@@ -29,6 +29,7 @@ var sayitEngines = {
     "es":       {name: "Google - Espaniol",        engine: "google",  params: []},
     "fr":       {name: "Google - Français",        engine: "google",  params: []},
     "ru_YA":    {name: "Yandex - Русский",         engine: "yandex",  params: ['key', 'voice', 'emotion', 'ill', 'drunk', 'robot'], voice: ['jane', 'zahar'], emotion: ['none', 'good', 'neutral', 'evil', 'mixed']},
+    "ru_YA_CLOUD":   {name: "Yandex Cloud - Русский",   engine: "yandexCloud",  params: ['key', 'folderID', 'voice', 'emotion'], voice: ['alyss', 'oksana', 'jane', 'zahar'], emotion: [ 'good', 'neutral', 'evil']},
 
     "en-US":    {name: "PicoTTS - Englisch US",    engine: "PicoTTS", params: []},
     "en-GB":    {name: "PicoTTS - Englisch GB",    engine: "PicoTTS", params: []},

--- a/admin/engines.js
+++ b/admin/engines.js
@@ -8,6 +8,7 @@ var sayitEngines = {
     "es":       {name: "Google - Espaniol",        engine: "google",  params: []},
     "fr":       {name: "Google - Français",        engine: "google",  params: []},
     "ru_YA":    {name: "Yandex - Русский",         engine: "yandex",  params: ['key', 'voice', 'emotion', 'ill', 'drunk', 'robot'], voice: ['jane', 'zahar'], emotion: ['none', 'good', 'neutral', 'evil', 'mixed']},
+    "ru_YA_CLOUD":   {name: "Yandex Cloud - Русский",   engine: "yandexCloud",  params: ['key', 'folderID', 'voice', 'emotion'], voice: ['alyss', 'oksana', 'jane', 'zahar'], emotion: [ 'good', 'neutral', 'evil']},
 
     "ru-RU_CLOUD_Female":       {gender: "Female", engine: "cloud",   params: ['cloud'], language: "ru-RU",      ename: "Tatyana",    ssml: true, name: "Cloud - Русский - Татьяна"},
     "ru-RU_CLOUD_Male":         {gender: "Male",   engine: "cloud",   params: ['cloud'], language: "ru-RU",      ename: "Maxim",      ssml: true, name: "Cloud - Русский - Максим"},

--- a/admin/index.html
+++ b/admin/index.html
@@ -609,6 +609,7 @@
                 <select class="value" id="player" >
                     <option value="mpg321">mpg321</option>
                     <option value="omxplayer">omxplayer</option>
+                     <option value="mplayer">mplayer</option>
                 </select><span class="translate" style="padding-left: 10px; font-size: 10px">Ignore for non linux OS</span>
             </td>
             </tr>
@@ -634,6 +635,7 @@
             <tr id="tr_webServer"  class="variable"><td><label class="translate" for="webServer">Web server IP:</label></td><td class="admin-icon"></td><td><select class="value" id="webServer"></select></td></tr>
             <tr id="tr_voice"      class="engine"  ><td><label class="translate" for="voice">Voice:</label></td><td class="admin-icon"></td><td><select class="value" id="voice"></select></td></tr>
             <tr id="tr_key"        class="engine"  ><td><label class="translate" for="key">API Key:</label></td><td class="admin-icon"></td><td><input class="value" id="key" type="text"/></td></tr>
+            <tr id="tr_folderID"   class="engine"  ><td><label class="translate" for="key">Folder ID:</label></td><td class="admin-icon"></td><td><input class="value" id="folderID" type="text"/></td></tr>
             <tr id="tr_emotion"    class="engine"  ><td><label class="translate" for="emotion">Emotion:</label></td><td class="admin-icon"></td><td><select class="value" id="emotion"></select></td></tr>
             <tr id="tr_drunk"      class="engine"  ><td><label class="translate" for="drunk">Drunk:</label></td><td class="admin-icon"></td><td><input type="checkbox" class="value" id="drunk"/></td></tr>
             <tr id="tr_ill"        class="engine"  ><td><label class="translate" for="ill">Ill:</label></td><td class="admin-icon"></td><td><input type="checkbox" class="value" id="ill"/></td></tr>

--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -621,6 +621,7 @@
                     <select class="value" id="player" >
                         <option value="mpg321">mpg321</option>
                         <option value="omxplayer">omxplayer</option>
+                        <option value="mplayer">mplayer</option>
                     </select>
                     <label for="player"><span class="translate">Linux player:</span><span class="translate" style="padding-left: 10px; font-size: 10px">Ignore for non linux OS</span></label>
                 </div>
@@ -751,6 +752,12 @@
                 <div class="input-field col s6 m4 l2">
                     <input class="value" id="key" type="text"/>
                     <label class="translate" for="key">API Key:</label>
+                </div>
+            </div>
+            <div id="tr_folderID"        class="row engine"  >
+                <div class="input-field col s6 m4 l2">
+                    <input class="value" id="folderID" type="text"/>
+                    <label class="translate" for="key">Folder ID:</label>
                 </div>
             </div>
             <div id="tr_emotion"    class="row engine"  >

--- a/lib/speech2device.js
+++ b/lib/speech2device.js
@@ -382,12 +382,10 @@ function Speech2Device(adapter, libs, options) {
 
                     if (adapter.config.player === 'omxplayer') {
                         cmd = 'omxplayer -o local ' + file;
-                    } else
-                      if (adapter.config.player === 'mpg321') {
+                    } else if (adapter.config.player === 'mpg321') {
                         cmd = 'mpg321 -g ' + options.sayLastVolume + ' ' + file;
-                    } else
-                    {
-                      cmd = 'mplayer ' + file;
+                    } else {
+                        cmd = 'mplayer ' + file;
                     } 
                     ls = libs.child_process.exec(cmd, (error /* , stdout, stderr */) => {
                         if (error) adapter.log.error('Cannot play:' + error);

--- a/lib/speech2device.js
+++ b/lib/speech2device.js
@@ -382,9 +382,13 @@ function Speech2Device(adapter, libs, options) {
 
                     if (adapter.config.player === 'omxplayer') {
                         cmd = 'omxplayer -o local ' + file;
-                    } else {
+                    } else
+                      if (adapter.config.player === 'mpg321') {
                         cmd = 'mpg321 -g ' + options.sayLastVolume + ' ' + file;
-                    }
+                    } else
+                    {
+                      cmd = 'mplayer ' + file;
+                    } 
                     ls = libs.child_process.exec(cmd, (error /* , stdout, stderr */) => {
                         if (error) adapter.log.error('Cannot play:' + error);
                         adapter.setState('tts.playing', false);

--- a/lib/text2speech.js
+++ b/lib/text2speech.js
@@ -207,7 +207,7 @@ function yandexGetIAM(AuthToken) {
         var querystring = require('querystring');
         var https = require('https');
         var postData = {
-            "yandexPassportOauthToken": AuthToken,
+            yandexPassportOauthToken: AuthToken,
         };
         var postBody = JSON.stringify(postData);
         var options = {
@@ -221,10 +221,10 @@ function yandexGetIAM(AuthToken) {
         };
 
         var now = Date.now();
-        if (now - lastAttempt > 36000000 || IAM=== '') {
+        if (now - lastAttempt > 36000000 || IAM === '') {
             lastAttempt=now;
             const req = https.request(options, res => {
-                adapter.log.debug("Requesting new IAM token..");
+                adapter.log.debug('Requesting new IAM token...');
                 var body = '';
                 res.on('data', chunk => body += chunk);
 
@@ -234,20 +234,20 @@ function yandexGetIAM(AuthToken) {
                         adapter.log.debug('IAM Received');
                         if (callback) callback(IAM);
                     }
-                    catch (e) { adapter.log.error("Response parse error"); callback(''); }
+                    catch (e) { 
+                        adapter.log.error("Response parse error"); callback(''); 
+                    }
                 });
-            }).on('error', err => {
-                adapter.log.error("Error: " + err);
-            });
+            }).on('error', err => adapter.log.error("Error: " + err));
 
-            req.on('error', (error) => {
-                adapter.log.error("Error: " + error)
-            });
+            req.on('error', error => adapter.log.error("Error: " + error));
 
             req.write(postBody);
             req.end();
-        } else {adapter.log.info("we still have actual IAM"); callback(IAM);}
-
+        } else {
+            adapter.log.info('we still have actual IAM'); 
+            callback(IAM);
+        }
     };
 };
 
@@ -262,15 +262,15 @@ function sayItGetSpeechYandexCloud(text, language, volume, callback) {
     if (!yandexCloudIAM) {
         yandexCloudIAM = yandexGetIAM(adapter.config.key);
         adapter.log.debug('Get IAM token for ' + adapter.config.key);
-        }
+    }
 
-        yandexCloudIAM(function (IAM) {
+    yandexCloudIAM(IAM => {
 
             var postData = {
-                "voice": adapter.config.voice,
-                "emotion": adapter.config.emotion,
-                "folderId": adapter.config.folderID,
-                "text": text
+                voice: adapter.config.voice,
+                emotion: adapter.config.emotion,
+                folderId: adapter.config.folderID,
+                text
             };
 
             var postBody = querystring.stringify(postData);
@@ -314,22 +314,16 @@ function sayItGetSpeechYandexCloud(text, language, volume, callback) {
                 if (callback) callback('Cannot get file: ' + err, text, language, volume);
             });
 
-            req.on('error', (error) => {
-                adapter.log.error(error)
-            });
+            req.on('error', error => adapter.log.error(error));
 
             try {
-
-            req.write(postBody);
-            req.end();
+                req.write(postBody);
+                req.end();
             }
             catch(e) {
-            adapter.log.error('Cannot connect to Yandex Cloud ' );
+                adapter.log.error('Cannot connect to Yandex Cloud ' );
             }
-
-        }
-        );
-
+        });
 };
 
 

--- a/lib/text2speech.js
+++ b/lib/text2speech.js
@@ -8,6 +8,7 @@ function Text2Speech(adapter, libs, options, sayIt) {
     let appkey         = null;
     let cloudUrl       = null;
     let polly          = null;
+    let YandexCloudIAM = null;
 
     function splitText(text, max) {
         if (!max) max = 70;
@@ -197,6 +198,140 @@ function Text2Speech(adapter, libs, options, sayIt) {
             if (callback) callback('Cannot get file:' + err, text, language, volume);
         });
     }
+/**/
+
+function YandexGetIAM(AuthToken) {
+    var lastAttempt = 0;
+    var IAM = '';
+    return function (callback) {
+        var querystring = require('querystring');
+        var https = require('https');
+        var postData = {
+            "yandexPassportOauthToken": AuthToken,
+        };
+        var postBody = JSON.stringify(postData);
+        var options = {
+            headers: {
+                'Content-Type': 'application/json',
+                'Content-Length': postBody.length
+            },
+            method: 'POST',
+            host: 'iam.api.cloud.yandex.net',
+            path: '/iam/v1/tokens'
+        };
+
+        var now = Date.now();
+        if (now - lastAttempt > 36000000 || IAM=== '') {
+            lastAttempt=now;
+            const req = https.request(options, res => {
+                adapter.log.debug("Requesting new IAM token..");
+                var body = '';
+                res.on('data', chunk => body += chunk);
+
+                res.on('end', () => {
+                    try {
+                        IAM = JSON.parse(body).iamToken;
+                        adapter.log.debug('IAM Received');
+                        if (callback) callback(IAM);
+                    }
+                    catch (e) { adapter.log.error("Response parse error"); callback(''); }
+                });
+            }).on('error', err => {
+                adapter.log.error("Error: " + err);
+            });
+
+            req.on('error', (error) => {
+                adapter.log.error("Error: " + error)
+            });
+
+            req.write(postBody);
+            req.end();
+        } else {adapter.log.info("we still have actual IAM"); callback(IAM);}
+
+    };
+};
+
+function sayItGetSpeechYandexCloud(text, language, volume, callback) {
+    if (language === 'ru' || language === 'ru_YA' || language === 'ru_YA_CLOUD') {
+        language = 'ru-RU';
+    };
+
+    var querystring = require('querystring');
+    if (!libs.https) libs.https = require('https');
+
+    if (!YandexCloudIAM) {
+        YandexCloudIAM = YandexGetIAM(adapter.config.key);
+        adapter.log.debug('Get IAM token for ' + adapter.config.key);
+        }
+
+        YandexCloudIAM(function (IAM) {
+
+            var postData = {
+                "voice": adapter.config.voice,
+                "emotion": adapter.config.emotion,
+                "folderId": adapter.config.folderID,
+                "text": text
+            };
+
+            var postBody = querystring.stringify(postData);
+
+            var options = {
+                headers: {
+                    'Authorization': 'Bearer ' + IAM,
+                    'Transfer-Encoding': 'chunked',
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                    'Content-Length': postBody.length
+                },
+                method: 'POST',
+                host: 'tts.api.cloud.yandex.net',
+                path: '/speech/v1/tts:synthesize'
+            };
+
+
+            let sounddata = '';
+            const req = libs.https.request(options, res => {
+                res.setEncoding('binary');
+                adapter.log.debug(res.statusCode);
+                adapter.log.debug(JSON.stringify(res.headers));
+
+                res.on('data', chunk => sounddata += chunk);
+
+                res.on('end', () => {
+                    if (sounddata.length < 100) {
+                        if (callback) callback('Cannot get file: received file is too short', text, language, volume, 0);
+                        return;
+                    }
+                    libs.fs.writeFile(MP3FILE, sounddata, 'binary', err => {
+                        if (err) {
+                            if (callback) callback('File error: ' + err, text, language, volume, 0);
+                        } else {
+                            if (callback) callback(null, text, language, volume);
+                        }
+                    });
+                });
+            }).on('error', err => {
+                sounddata = '';
+                if (callback) callback('Cannot get file: ' + err, text, language, volume);
+            });
+
+            req.on('error', (error) => {
+                adapter.log.error(error)
+            });
+
+            try {
+
+            req.write(postBody);
+            req.end();
+            }
+            catch(e) {
+            adapter.log.error('Cannot connect to Yandex Cloud ' );
+            }
+
+        }
+        );
+
+};
+
 
     function sayItGetSpeechYandex(text, language, volume, callback) {
         if (language === 'ru' || language === 'ru_YA') {
@@ -434,6 +569,7 @@ function Text2Speech(adapter, libs, options, sayIt) {
     const ENGINES = {
         'google':   sayItGetSpeechGoogle,
         'yandex':   sayItGetSpeechYandex,
+        'yandexCloud':   sayItGetSpeechYandexCloud,
         'acapela':  sayItGetSpeechAcapela,
         'polly':    sayItGetSpeechPolly,
         'cloud':    sayItGetSpeechCloud,

--- a/lib/text2speech.js
+++ b/lib/text2speech.js
@@ -8,7 +8,7 @@ function Text2Speech(adapter, libs, options, sayIt) {
     let appkey         = null;
     let cloudUrl       = null;
     let polly          = null;
-    let YandexCloudIAM = null;
+    let yandexCloudIAM = null;
 
     function splitText(text, max) {
         if (!max) max = 70;
@@ -200,7 +200,7 @@ function Text2Speech(adapter, libs, options, sayIt) {
     }
 /**/
 
-function YandexGetIAM(AuthToken) {
+function yandexGetIAM(AuthToken) {
     var lastAttempt = 0;
     var IAM = '';
     return function (callback) {
@@ -259,12 +259,12 @@ function sayItGetSpeechYandexCloud(text, language, volume, callback) {
     var querystring = require('querystring');
     if (!libs.https) libs.https = require('https');
 
-    if (!YandexCloudIAM) {
-        YandexCloudIAM = YandexGetIAM(adapter.config.key);
+    if (!yandexCloudIAM) {
+        yandexCloudIAM = yandexGetIAM(adapter.config.key);
         adapter.log.debug('Get IAM token for ' + adapter.config.key);
         }
 
-        YandexCloudIAM(function (IAM) {
+        yandexCloudIAM(function (IAM) {
 
             var postData = {
                 "voice": adapter.config.voice,


### PR DESCRIPTION
It looks like Yandex is going to close current SpeechKIT at the end of the year and currently everything is moved to Yandex.Cloud platform. 
This update adds support for Yandex.Cloud speechKIT API for those who is going to continue with Yandex text to speech engine. 
The major difference of new API is that it only supports OGG and raw LPCM file formats (no mp3). On linux I found only one simple solution to play OGG files - mplayer. By default mplayer does not look to the file extension, so we even do not need to change it in adapter, unless there will be any problems playing .mp3 files with ogg content using any other players. Browser seems to be playing such files Ok as well. 

PS: I'm not a good javascript programmer, so code might be inefficient at some places :) 