### PR TITLE
Play local file in mp24 without ftp

### DIFF
--- a/lib/speech2device.js
+++ b/lib/speech2device.js
@@ -249,26 +249,51 @@ function Speech2Device(adapter, libs, options) {
         }
 
 
-        if (adapter.config.server && !isPlayFile(text)) {
-            adapter.log.debug('Request MediaPlayer24 "http://' + adapter.config.server + ':50000/tts=' + encodeURI(text) + '"');
-            const opts = {
-                host: adapter.config.server,
-                port: 50000,
-                path: '/tts=' + encodeURI(text)
-            };
-            libs.http.get(opts, res => {
-                let body = '';
-                res.on('data', chunk => body += chunk);
-                // all data has been downloaded
-                res.on('end', () => adapter.log.debug('Response from MediaPlayer24 "' + adapter.config.server + '": ' + body));
-                res.on('error', e => adapter.log.error('Cannot say text on MediaPlayer24 "' + adapter.config.server + '": ' + e.message));
-            }).on('error', e => {
-                if (e.message === 'Parse Error') {
-                    adapter.log.debug('Played successfully');
-                } else {
-                    error = 'Cannot say text on MediaPlayer24 "' + adapter.config.server + '":' + e.message;
-                }
-            });
+        if (adapter.config.server) {
+			if (isPlayFile(text) === false) {
+				// say
+				adapter.log.debug('Request MediaPlayer24 "http://' + adapter.config.server + ':50000/tts=' + encodeURI(text) + '"');
+				const opts = {
+					host: adapter.config.server,
+					port: 50000,
+					path: '/tts=' + encodeURI(text)
+				};
+				libs.http.get(opts, res => {
+					let body = '';
+					res.on('data', chunk => body += chunk);
+					// all data has been downloaded
+					res.on('end', () => adapter.log.debug('Response from MediaPlayer24 "' + adapter.config.server + '": ' + body));
+					res.on('error', e => adapter.log.error('Cannot say text on MediaPlayer24 "' + adapter.config.server + '": ' + e.message));
+				}).on('error', e => {
+					if (e.message === 'Parse Error') {
+						adapter.log.debug('Played successfully');
+					} else {
+						error = 'Cannot say text on MediaPlayer24 "' + adapter.config.server + '":' + e.message;
+					}
+				});
+			} else {
+				// play local file
+				const opts = {
+					host: adapter.config.server,
+					port: 50000,
+					path: '/track=' + text
+				};
+				
+				libs.http.get(opts, res => {
+					let body = '';
+					res.on('data', chunk => body += chunk);
+					// all data has been downloaded
+					res.on('end', () => adapter.log.debug('Response from MediaPlayer24 "' + adapter.config.server + '": ' + body));
+					res.on('error', e => adapter.log.error('Cannot play local file on MediaPlayer24 "' + adapter.config.server + '":' + e.message));
+				}).on('error', e => {
+					if (e.message === 'Parse Error') {
+						adapter.log.debug('Played successfully');
+					} else {
+						adapter.log.error('Cannot play local file on MediaPlayer24 "' + adapter.config.server + '":' + e.message);
+					}
+				});
+			}
+            
         }
 
         callback && callback(error, duration + 2);

--- a/lib/speech2device.js
+++ b/lib/speech2device.js
@@ -250,7 +250,7 @@ function Speech2Device(adapter, libs, options) {
 
 
         if (adapter.config.server) {
-			if (isPlayFile(text) === false) {
+			if (!isPlayFile(text)) {
 				// say
 				adapter.log.debug('Request MediaPlayer24 "http://' + adapter.config.server + ':50000/tts=' + encodeURI(text) + '"');
 				const opts = {


### PR DESCRIPTION
Play local file for MediaPlayer24 without FTP.
The file must be located on the device on which MediaPlayer24 is installed.
Use case - doorbell