### PR TITLE
Update dependencies (admin 7, js-controller 5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,10 @@ The following values for engines are possible:
 	### **WORK IN PROGRESS**
 -->
 ## Changelog
+### **WORK IN PROGRESS**
+* (mcm1957) Adapter requires admin v7 or newer now
+* (mcm1957) Adapter requires jas-controller 5 or newer now
+
 ### 4.0.5 (2024-07-12)
 * (bluefox) Packages updated
 * (bluefox) Corrected playing in vis

--- a/io-package.json
+++ b/io-package.json
@@ -160,7 +160,12 @@
     },
     "dependencies": [
       {
-        "js-controller": ">=2.0.0"
+        "js-controller": ">=5.0.19"
+      }
+    ],
+    "globalDependencies": [
+      {
+        "admin": ">=7.0.13"
       }
     ]
   },


### PR DESCRIPTION
According to statement at forum, sayit requires admin 7.

This PR adds admin dependency (for current 7.x.x release) and bumps js-controller to current js-controller 5.

@GermanBluefox 
@Apollon77 

Please review / merge and create a new (minor ?) Release to publish the requirement.